### PR TITLE
Update code to work with Python 3

### DIFF
--- a/code/bigviktor/dga.py
+++ b/code/bigviktor/dga.py
@@ -421,7 +421,7 @@ class domain_generator:
     
     def generate_domains(self, nr):
         for d in range(nr):
-            print self.generate_domain()
+            print(self.generate_domain())
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/code/ccleaner/dga.py
+++ b/code/ccleaner/dga.py
@@ -20,7 +20,7 @@ def dga(year, month, nr, tlds):
     sld = 'ab%x%x' %(r2 * r3, r1)
 
     domain = sld + '.' + tlds[0]
-    print domain
+    print(domain)
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()

--- a/code/enviserv/dga.py
+++ b/code/enviserv/dga.py
@@ -12,16 +12,16 @@ def dga(seed, nr, tlds):
         #print seed_str
 
         s = hashlib.md5()
-        s.update(seed_str)
+        s.update(seed_str.encode('latin1'))
         x = s.digest()
 
         domain = ""
         for j in range(5):
-            domain += "%02x" %(ord(x[j]))
+            domain += "%02x" %(x[j])
 
         domain += '.' + tlds[i % 6]
 
-        print domain
+        print(domain)
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()

--- a/code/mydoom/dga.py
+++ b/code/mydoom/dga.py
@@ -35,7 +35,7 @@ def dga(date, seed, nr, tlds):
 
             m = m / len_sld
 
-        print sld + '.' + tld
+        print(sld + '.' + tld)
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()

--- a/code/vidro/dga.py
+++ b/code/vidro/dga.py
@@ -11,7 +11,7 @@ def rand(seed):
 def dga(epoch, nr):
     tlds = ['dyndns.org', 'com', 'net']
     seed_init = 0x1e240 * \
-           (((epoch-0x4BEFB280)<<32)/(0x93a80<<32)+0x3ed)
+           (((epoch-0x4BEFB280)<<32)//(0x93a80<<32)+0x3ed)
 
     for i in range(nr):
         seed = i % 100 + seed_init
@@ -24,7 +24,7 @@ def dga(epoch, nr):
             domain += chr(r % 26 + ord('a'))
 
         domain += '.' + tlds[i % 3]
-        print domain
+        print(domain)
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()

--- a/code/xshellghost/dga.py
+++ b/code/xshellghost/dga.py
@@ -10,15 +10,15 @@ def dga(year, month, nr, tlds):
     _year = c_uint(year)
     _month = c_uint(month)
     seed = c_uint(0)
-    print _year.value
-    print _month.value
+    print(_year.value)
+    print(_month.value)
 
     seed.value = 0x90422a3a * _month.value
-    print "%x" %(seed.value)
+    print("%x" %(seed.value))
     seed.value -= 0x39d06f76 * _year.value
-    print "%x" %(seed.value)
+    print("%x" %(seed.value))
     seed.value -= 0x67b7fc6f
-    print "%x" %(seed.value)
+    print("%x" %(seed.value))
     
     sld_len = seed.value % 6 + 10
     sld = ''
@@ -27,7 +27,7 @@ def dga(year, month, nr, tlds):
         seed.value = 29 * seed.value + 19
 
     domain = sld + '.' + tlds[0]
-    print domain
+    print(domain)
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Given Python 2 has hit the end of life, we should update code to Python 3. This PR changes all the DGA generators to run correctly, and yield identical output, with Python 3.